### PR TITLE
Patch 1

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "..:/var/www/html"
     command: sleep infinity
     depends_on:
-      db
+      - db
 volumes:
   database:
   # acquia:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,10 @@ services:
       - "./config/mysql.cnf:/etc/mysql/conf.d/zmysql.cnf"
       - database:/var/lib/mysql
       # - "../dump/init.sql:/docker-entrypoint-initdb.d/mydb.sql"
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
   app:
 #     image: alchatti/drupal-devcontainer:8.1
     image: mcr.microsoft.com/devcontainers/php:8.0

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -31,6 +31,8 @@ services:
 #       - "../.dev:/var/www/site-dev"
       - "..:/var/www/html"
     command: sleep infinity
+    depends_on:
+      db
 volumes:
   database:
   # acquia:


### PR DESCRIPTION
docker compose isn't terribly smart about waiting for sql databases to start/initialize/etc.  this pr adds a health check and tells the `app` container to wait until the `db` container is healthy first.